### PR TITLE
feat(task-282): manage courses

### DIFF
--- a/frontend/src/app/admin/settings/page.tsx
+++ b/frontend/src/app/admin/settings/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import AttendanceTypeSection from "@/features/attendance-types/components/AttendanceTypeSection";
+import CourseSection from "@/features/courses/components/CourseSection";
 
 export default function SettingsPage() {
   return (
     <div className="flex flex-col min-h-[calc(100vh-100px)] overflow-auto p-4 md:p-8 gap-6 font-sans">
       <AttendanceTypeSection />
+      <CourseSection />
     </div>
   );
 }

--- a/frontend/src/app/admin/students/[studentId]/edit/page.tsx
+++ b/frontend/src/app/admin/students/[studentId]/edit/page.tsx
@@ -25,12 +25,10 @@ export default function EditStudentPage() {
       try {
         setIsLoading(true);
 
-        const allStudents = await studentService.getStudents();
+        const student = await studentService.getStudentById(id);
 
-        const foundStudent = allStudents.find((s) => s.externalId === id);
-
-        if (foundStudent) {
-          const formattedData = formatForFrontend(foundStudent);
+        if (student) {
+          const formattedData = formatForFrontend(student);
           setStudentData(formattedData);
         } else {
           console.error("Student not found.");

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Menu,
   PanelLeftClose,
   PanelLeftOpen,
+  Settings,
   Users,
   X,
 } from "lucide-react";
@@ -38,6 +39,12 @@ export default function Sidebar() {
       icon: CalendarFold,
       id: "Envio",
       href: PATHS.attendances_list,
+    },
+    {
+      label: "Cadastros Gerais",
+      icon: Settings,
+      id: "Configuração",
+      href: PATHS.visualize_settings,
     },
   ];
 

--- a/frontend/src/constants/paths.ts
+++ b/frontend/src/constants/paths.ts
@@ -12,4 +12,5 @@ export const PATHS = {
     `/admin/students/${studentId}/attendance/${attendanceId}`,
   edit_attendance: (studentId: string, attendanceId: string) =>
     `/admin/students/${studentId}/attendance/${attendanceId}/edit`,
+  visualize_settings: "/admin/settings",
 };

--- a/frontend/src/features/courses/components/CourseModal.tsx
+++ b/frontend/src/features/courses/components/CourseModal.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { ConfirmModal } from "@/components/ui/ConfirmModal";
 import CommonButton from "@/components/ui/CommonButton";
+import { ConfirmModal } from "@/components/ui/ConfirmModal";
 import { Field } from "@/components/ui/Field";
 import { FormModal } from "@/components/ui/FormModal";
+import { formatDate } from "@/utils/utils";
 import { Eye } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useCoursesSettings } from "../hooks/useCoursesSettings";
@@ -14,35 +15,22 @@ interface CourseModalProps {
   onClose: () => void;
   courseId: string | null;
   onSuccess: () => void;
-  courses?: Course[];
 }
 
 const inputClass =
   "w-full px-3.5 py-2.5 border-[1.5px] rounded-md bg-white text-sm text-stone-800 outline-none transition-colors font-sans border-stone-300 hover:border-stone-400 focus:border-teal-400 disabled:text-stone-500 disabled:cursor-not-allowed";
-
-const formatDate = (value: string) => {
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return new Intl.DateTimeFormat("pt-BR").format(date);
-};
 
 export function CourseModal({
   isOpen,
   onClose,
   courseId,
   onSuccess,
-  courses = [],
 }: CourseModalProps) {
   const { getCourseById, createCourse, updateCourse, removeCourse } =
     useCoursesSettings(false);
 
-  const [mode, setMode] = useState<"create" | "view" | "edit">(
-    courseId ? "view" : "create",
-  );
+  const [mode, setMode] = useState<"create" | "view" | "edit">("create");
+
   const [name, setName] = useState("");
   const [acronym, setAcronym] = useState("");
   const [coordinatorId, setCoordinatorId] = useState("");
@@ -52,39 +40,31 @@ export function CourseModal({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   useEffect(() => {
-    if (!isOpen || !courseId) return;
-
-    getCourseById(courseId).then((data) => {
-      if (data) {
-        setName(data.name);
-        setAcronym(data.acronym);
-        setCoordinatorId(data.coordinatorId ?? "");
-        setCourseData(data);
+    if (isOpen) {
+      if (courseId) {
+        setMode("view");
+        getCourseById(courseId).then((data) => {
+          if (data) {
+            setName(data.name);
+            setAcronym(data.acronym);
+            setCoordinatorId(data.coordinatorId ?? "");
+            setCourseData(data);
+          }
+        });
+      } else {
+        setMode("create");
+        setName("");
+        setAcronym("");
+        setCoordinatorId("");
+        setCourseData(null);
       }
-    });
-  }, [courseId, isOpen]);
+    }
+  }, [isOpen, courseId]);
 
   const handleSecondaryAction = () => {
     if (mode === "view" && courseId) {
       setIsDeleteModalOpen(true);
-      return;
-    }
-
-    onClose();
-  };
-
-  const handleCancelDelete = () => {
-    setIsDeleteModalOpen(false);
-  };
-
-  const handleConfirmDelete = async () => {
-    if (!courseId) return;
-
-    const success = await removeCourse(courseId);
-
-    if (success) {
-      setIsDeleteModalOpen(false);
-      onSuccess();
+    } else {
       onClose();
     }
   };
@@ -104,33 +84,13 @@ export function CourseModal({
       coordinatorId: coordinatorId.trim() || undefined,
     };
 
-    if (!payload.name) {
-      setNameError(
-        mode === "edit"
-          ? "O nome do curso não pode ficar vazio"
-          : "O nome do curso é obrigatório",
-      );
+    if (!name) {
+      setNameError("O nome do curso é obrigatório.");
       return;
     }
 
-    if (!payload.acronym) {
-      setAcronymError("A sigla do curso é obrigatória");
-      return;
-    }
-
-    const hasDuplicatedName = courses.some(
-      (course) =>
-        course.externalId !== courseId &&
-        course.name.trim().toLowerCase() === payload.name.toLowerCase(),
-    );
-
-    if (mode === "create" && hasDuplicatedName) {
-      setNameError("Este curso já está cadastrado no sistema");
-      return;
-    }
-
-    if (mode === "edit" && hasDuplicatedName) {
-      setNameError("Já existe um curso cadastrado com este nome");
+    if (!acronym) {
+      setAcronymError("A sigla do curso é obrigatória.");
       return;
     }
 
@@ -149,10 +109,28 @@ export function CourseModal({
     }
   };
 
+  // Confirm Modal to Delete
+  const handleCancelDelete = () => {
+    setIsDeleteModalOpen(false);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!courseId) return;
+
+    const success = await removeCourse(courseId);
+
+    if (success) {
+      setIsDeleteModalOpen(false);
+      onSuccess();
+      onClose();
+    }
+  };
+
   const modalTitle =
     mode === "view" ? "Visualizar" : mode === "create" ? "Cadastrar" : "Editar";
 
   const isViewMode = mode === "view";
+
   const coordinatorDisplayValue =
     isViewMode && courseData?.coordinatorName
       ? courseData.coordinatorName
@@ -173,7 +151,12 @@ export function CourseModal({
             {mode === "edit" && (
               <CommonButton
                 label="Visualizar"
-                onClick={() => setMode("view")}
+                onClick={() => {
+                  setMode("view");
+                  setName(courseData?.name || "");
+                  setAcronym(courseData?.acronym || "");
+                  setCoordinatorId(courseData?.coordinatorId || "");
+                }}
                 startIcon={Eye}
               />
             )}
@@ -224,7 +207,7 @@ export function CourseModal({
           />
         </Field>
 
-        <Field label="Coordenador(a) do Curso:">
+        {/* <Field label="Coordenador(a) do Curso:">
           <input
             disabled={isViewMode}
             type="text"
@@ -233,12 +216,16 @@ export function CourseModal({
             placeholder="Insira o ID do coordenador"
             className={inputClass}
           />
-        </Field>
+        </Field> */}
 
-        {mode !== "create" && courseData && (
+        {mode === "view" && courseData && (
           <div className="flex gap-4 text-xs text-stone-500">
-            <span>Criado em {formatDate(courseData.createdAt)}</span>
-            <span>Editado em {formatDate(courseData.updatedAt)}</span>
+            <span>
+              <strong>Criado em:</strong> {formatDate(courseData.createdAt)}
+            </span>
+            <span>
+              <strong>Atualizado em:</strong> {formatDate(courseData.updatedAt)}
+            </span>
           </div>
         )}
       </FormModal>

--- a/frontend/src/features/courses/components/CourseModal.tsx
+++ b/frontend/src/features/courses/components/CourseModal.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { ConfirmModal } from "@/components/ui/ConfirmModal";
+import CommonButton from "@/components/ui/CommonButton";
+import { Field } from "@/components/ui/Field";
+import { FormModal } from "@/components/ui/FormModal";
+import { Eye } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useCoursesSettings } from "../hooks/useCoursesSettings";
+import { Course } from "../types/course";
+
+interface CourseModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  courseId: string | null;
+  onSuccess: () => void;
+  courses?: Course[];
+}
+
+const inputClass =
+  "w-full px-3.5 py-2.5 border-[1.5px] rounded-md bg-white text-sm text-stone-800 outline-none transition-colors font-sans border-stone-300 hover:border-stone-400 focus:border-teal-400 disabled:text-stone-500 disabled:cursor-not-allowed";
+
+const formatDate = (value: string) => {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("pt-BR").format(date);
+};
+
+export function CourseModal({
+  isOpen,
+  onClose,
+  courseId,
+  onSuccess,
+  courses = [],
+}: CourseModalProps) {
+  const { getCourseById, createCourse, updateCourse, removeCourse } =
+    useCoursesSettings(false);
+
+  const [mode, setMode] = useState<"create" | "view" | "edit">(
+    courseId ? "view" : "create",
+  );
+  const [name, setName] = useState("");
+  const [acronym, setAcronym] = useState("");
+  const [coordinatorId, setCoordinatorId] = useState("");
+  const [nameError, setNameError] = useState("");
+  const [acronymError, setAcronymError] = useState("");
+  const [courseData, setCourseData] = useState<Course | null>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || !courseId) return;
+
+    getCourseById(courseId).then((data) => {
+      if (data) {
+        setName(data.name);
+        setAcronym(data.acronym);
+        setCoordinatorId(data.coordinatorId ?? "");
+        setCourseData(data);
+      }
+    });
+  }, [courseId, isOpen]);
+
+  const handleSecondaryAction = () => {
+    if (mode === "view" && courseId) {
+      setIsDeleteModalOpen(true);
+      return;
+    }
+
+    onClose();
+  };
+
+  const handleCancelDelete = () => {
+    setIsDeleteModalOpen(false);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!courseId) return;
+
+    const success = await removeCourse(courseId);
+
+    if (success) {
+      setIsDeleteModalOpen(false);
+      onSuccess();
+      onClose();
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (mode === "view") {
+      setMode("edit");
+      return;
+    }
+
+    setNameError("");
+    setAcronymError("");
+
+    const payload = {
+      name: name.trim(),
+      acronym: acronym.trim(),
+      coordinatorId: coordinatorId.trim() || undefined,
+    };
+
+    if (!payload.name) {
+      setNameError(
+        mode === "edit"
+          ? "O nome do curso não pode ficar vazio"
+          : "O nome do curso é obrigatório",
+      );
+      return;
+    }
+
+    if (!payload.acronym) {
+      setAcronymError("A sigla do curso é obrigatória");
+      return;
+    }
+
+    const hasDuplicatedName = courses.some(
+      (course) =>
+        course.externalId !== courseId &&
+        course.name.trim().toLowerCase() === payload.name.toLowerCase(),
+    );
+
+    if (mode === "create" && hasDuplicatedName) {
+      setNameError("Este curso já está cadastrado no sistema");
+      return;
+    }
+
+    if (mode === "edit" && hasDuplicatedName) {
+      setNameError("Já existe um curso cadastrado com este nome");
+      return;
+    }
+
+    if (mode === "create") {
+      const success = await createCourse(payload);
+      if (success) {
+        onSuccess();
+        onClose();
+      }
+    } else if (mode === "edit" && courseId) {
+      const success = await updateCourse(courseId, payload);
+      if (success) {
+        onSuccess();
+        onClose();
+      }
+    }
+  };
+
+  const modalTitle =
+    mode === "view" ? "Visualizar" : mode === "create" ? "Cadastrar" : "Editar";
+
+  const isViewMode = mode === "view";
+  const coordinatorDisplayValue =
+    isViewMode && courseData?.coordinatorName
+      ? courseData.coordinatorName
+      : coordinatorId;
+
+  const getInputClass = (error?: string) =>
+    `${inputClass} ${error ? "border-red-400 hover:border-red-400 focus:border-red-500" : ""}`;
+
+  return (
+    <>
+      <FormModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onBack={onClose}
+        title={`${modalTitle} Curso`}
+        footerActions={
+          <>
+            {mode === "edit" && (
+              <CommonButton
+                label="Visualizar"
+                onClick={() => setMode("view")}
+                startIcon={Eye}
+              />
+            )}
+            <div className="flex-1" />
+            <CommonButton
+              label={mode === "view" ? "Remover Curso" : "Cancelar"}
+              onClick={handleSecondaryAction}
+              className="bg-[#f4a598] hover:bg-[#f0a195] border-[#f0a195] text-white"
+            />
+            <CommonButton
+              label={
+                mode === "view"
+                  ? "Editar"
+                  : mode === "create"
+                    ? "Confirmar Cadastro"
+                    : "Salvar"
+              }
+              onClick={handleConfirm}
+            />
+          </>
+        }
+      >
+        <Field label="Nome do Curso:" required error={nameError}>
+          <input
+            disabled={isViewMode}
+            type="text"
+            value={name}
+            onChange={(event) => {
+              setName(event.target.value);
+              setNameError("");
+            }}
+            placeholder="Insira o nome do curso"
+            className={getInputClass(nameError)}
+          />
+        </Field>
+
+        <Field label="Sigla:" required error={acronymError}>
+          <input
+            disabled={isViewMode}
+            type="text"
+            value={acronym}
+            onChange={(event) => {
+              setAcronym(event.target.value);
+              setAcronymError("");
+            }}
+            placeholder="Insira a sigla"
+            className={getInputClass(acronymError)}
+          />
+        </Field>
+
+        <Field label="Coordenador(a) do Curso:">
+          <input
+            disabled={isViewMode}
+            type="text"
+            value={coordinatorDisplayValue}
+            onChange={(event) => setCoordinatorId(event.target.value)}
+            placeholder="Insira o ID do coordenador"
+            className={inputClass}
+          />
+        </Field>
+
+        {mode !== "create" && courseData && (
+          <div className="flex gap-4 text-xs text-stone-500">
+            <span>Criado em {formatDate(courseData.createdAt)}</span>
+            <span>Editado em {formatDate(courseData.updatedAt)}</span>
+          </div>
+        )}
+      </FormModal>
+
+      <ConfirmModal
+        open={isDeleteModalOpen}
+        title="Excluir Curso"
+        message={`Tem certeza que deseja excluir o curso ${name}? Esta ação removerá o curso permanentemente do catálogo.`}
+        confirmLabel="Excluir"
+        confirmColor="critical"
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+      />
+    </>
+  );
+}

--- a/frontend/src/features/courses/components/CourseModal.tsx
+++ b/frontend/src/features/courses/components/CourseModal.tsx
@@ -131,11 +131,6 @@ export function CourseModal({
 
   const isViewMode = mode === "view";
 
-  const coordinatorDisplayValue =
-    isViewMode && courseData?.coordinatorName
-      ? courseData.coordinatorName
-      : coordinatorId;
-
   const getInputClass = (error?: string) =>
     `${inputClass} ${error ? "border-red-400 hover:border-red-400 focus:border-red-500" : ""}`;
 

--- a/frontend/src/features/courses/components/CourseSection.tsx
+++ b/frontend/src/features/courses/components/CourseSection.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { ConfirmModal } from "@/components/ui/ConfirmModal";
+import CommonButton from "@/components/ui/CommonButton";
+import { InfoBadge } from "@/components/ui/InfoBadge";
+import { ManageSectionCard } from "@/components/ui/ManageSectionCard";
+import { SearchInput } from "@/components/ui/SearchInput";
+import { Plus, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useCoursesSettings } from "../hooks/useCoursesSettings";
+import { Course } from "../types/course";
+import { CourseModal } from "./CourseModal";
+
+export default function CourseSection() {
+  const { courses, fetchCourses, isLoading, removeCourse } =
+    useCoursesSettings();
+
+  const [searchFilter, setSearchFilter] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [selectedCourseToDelete, setSelectedCourseToDelete] =
+    useState<Course | null>(null);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      fetchCourses(searchFilter);
+    }, 300);
+
+    return () => window.clearTimeout(timeout);
+  }, [searchFilter]);
+
+  const handleOpenCreate = () => {
+    setSelectedId(null);
+    setIsModalOpen(true);
+  };
+
+  const handleOpenView = (externalId: string) => {
+    setSelectedId(externalId);
+    setIsModalOpen(true);
+  };
+
+  const handleOpenDeleteModal = (course: Course) => {
+    setSelectedCourseToDelete(course);
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleCancelDelete = () => {
+    setSelectedCourseToDelete(null);
+    setIsDeleteModalOpen(false);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!selectedCourseToDelete) return;
+
+    const success = await removeCourse(selectedCourseToDelete.externalId);
+
+    if (success) {
+      handleCancelDelete();
+    }
+  };
+
+  const isSearching = searchFilter.trim().length > 0;
+
+  return (
+    <>
+      <ManageSectionCard
+        title="Gerenciar Cursos"
+        searchInputs={
+          <SearchInput
+            placeholder="Buscar por Cursos"
+            value={searchFilter}
+            onChange={setSearchFilter}
+          />
+        }
+        actionButton={
+          <CommonButton
+            label="Adicionar Novo Curso"
+            endIcon={Plus}
+            onClick={handleOpenCreate}
+            className="min-w-70 justify-center"
+          />
+        }
+      >
+        {isLoading ? (
+          <span className="text-sm text-stone-500">Carregando cursos...</span>
+        ) : courses.length === 0 && !isSearching ? (
+          <span className="text-sm text-stone-500">
+            Nenhum curso cadastrado ainda.
+          </span>
+        ) : courses.length === 0 ? (
+          <span className="text-sm text-stone-500">
+            Nenhum curso encontrado.
+          </span>
+        ) : (
+          courses.map((course) => (
+            <div key={course.externalId} className="flex items-center gap-1">
+              <InfoBadge
+                label={`${course.name} (${course.acronym})`}
+                onClick={() => handleOpenView(course.externalId)}
+              />
+
+              <button
+                type="button"
+                title="Excluir curso"
+                onClick={() => handleOpenDeleteModal(course)}
+                className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-red-400 transition-colors hover:bg-red-100 hover:text-red-500"
+              >
+                <Trash2 size={16} />
+              </button>
+            </div>
+          ))
+        )}
+      </ManageSectionCard>
+
+      {isModalOpen && (
+        <CourseModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          courseId={selectedId}
+          onSuccess={() => fetchCourses(searchFilter)}
+          courses={courses}
+        />
+      )}
+
+      <ConfirmModal
+        open={isDeleteModalOpen}
+        title="Excluir Curso"
+        message={`Tem certeza que deseja excluir o curso ${selectedCourseToDelete?.name}? Esta ação removerá o curso permanentemente do catálogo.`}
+        confirmLabel="Excluir"
+        confirmColor="critical"
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+      />
+    </>
+  );
+}

--- a/frontend/src/features/courses/components/CourseSection.tsx
+++ b/frontend/src/features/courses/components/CourseSection.tsx
@@ -1,26 +1,20 @@
 "use client";
 
-import { ConfirmModal } from "@/components/ui/ConfirmModal";
 import CommonButton from "@/components/ui/CommonButton";
 import { InfoBadge } from "@/components/ui/InfoBadge";
 import { ManageSectionCard } from "@/components/ui/ManageSectionCard";
 import { SearchInput } from "@/components/ui/SearchInput";
-import { Plus, Trash2 } from "lucide-react";
+import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useCoursesSettings } from "../hooks/useCoursesSettings";
-import { Course } from "../types/course";
 import { CourseModal } from "./CourseModal";
 
 export default function CourseSection() {
-  const { courses, fetchCourses, isLoading, removeCourse } =
-    useCoursesSettings();
+  const { courses, fetchCourses, isLoading } = useCoursesSettings();
 
   const [searchFilter, setSearchFilter] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [selectedCourseToDelete, setSelectedCourseToDelete] =
-    useState<Course | null>(null);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
@@ -38,26 +32,6 @@ export default function CourseSection() {
   const handleOpenView = (externalId: string) => {
     setSelectedId(externalId);
     setIsModalOpen(true);
-  };
-
-  const handleOpenDeleteModal = (course: Course) => {
-    setSelectedCourseToDelete(course);
-    setIsDeleteModalOpen(true);
-  };
-
-  const handleCancelDelete = () => {
-    setSelectedCourseToDelete(null);
-    setIsDeleteModalOpen(false);
-  };
-
-  const handleConfirmDelete = async () => {
-    if (!selectedCourseToDelete) return;
-
-    const success = await removeCourse(selectedCourseToDelete.externalId);
-
-    if (success) {
-      handleCancelDelete();
-    }
   };
 
   const isSearching = searchFilter.trim().length > 0;
@@ -93,21 +67,12 @@ export default function CourseSection() {
             Nenhum curso encontrado.
           </span>
         ) : (
-          courses.map((course) => (
-            <div key={course.externalId} className="flex items-center gap-1">
+          courses.map((course, idx) => (
+            <div key={idx} className="flex items-center gap-1">
               <InfoBadge
                 label={`${course.name} (${course.acronym})`}
-                onClick={() => handleOpenView(course.externalId)}
+                onClick={() => handleOpenView(course.id)}
               />
-
-              <button
-                type="button"
-                title="Excluir curso"
-                onClick={() => handleOpenDeleteModal(course)}
-                className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-red-400 transition-colors hover:bg-red-100 hover:text-red-500"
-              >
-                <Trash2 size={16} />
-              </button>
             </div>
           ))
         )}
@@ -117,21 +82,10 @@ export default function CourseSection() {
         <CourseModal
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
-          courseId={selectedId}
           onSuccess={() => fetchCourses(searchFilter)}
-          courses={courses}
+          courseId={selectedId}
         />
       )}
-
-      <ConfirmModal
-        open={isDeleteModalOpen}
-        title="Excluir Curso"
-        message={`Tem certeza que deseja excluir o curso ${selectedCourseToDelete?.name}? Esta ação removerá o curso permanentemente do catálogo.`}
-        confirmLabel="Excluir"
-        confirmColor="critical"
-        onConfirm={handleConfirmDelete}
-        onCancel={handleCancelDelete}
-      />
     </>
   );
 }

--- a/frontend/src/features/courses/hooks/useCoursesOptions.ts
+++ b/frontend/src/features/courses/hooks/useCoursesOptions.ts
@@ -9,10 +9,10 @@ export const useCoursesOptions = () => {
   useEffect(() => {
     const fetchCourses = async () => {
       try {
-        const response = await coursesService.get();
+        const response = await coursesService.getAllCourses(1, 100);
 
-        const mappedOptions: SelectOption[] = response.map((course) => ({
-          value: String(course.id),
+        const mappedOptions: SelectOption[] = response.data.map((course) => ({
+          value: course.externalId,
           label: course.name,
         }));
 

--- a/frontend/src/features/courses/hooks/useCoursesOptions.ts
+++ b/frontend/src/features/courses/hooks/useCoursesOptions.ts
@@ -11,8 +11,8 @@ export const useCoursesOptions = () => {
       try {
         const response = await coursesService.getAllCourses(1, 100);
 
-        const mappedOptions: SelectOption[] = response.data.map((course) => ({
-          value: course.externalId,
+        const mappedOptions: SelectOption[] = response.items.map((course) => ({
+          value: course.id,
           label: course.name,
         }));
 

--- a/frontend/src/features/courses/hooks/useCoursesSettings.ts
+++ b/frontend/src/features/courses/hooks/useCoursesSettings.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import { coursesService } from "../services/courseService";
+import { Course, CoursePayload } from "../types/course";
+
+export function useCoursesSettings(autoFetch = true) {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchCourses = async (nameOrAcronym = "") => {
+    setIsLoading(true);
+
+    try {
+      const response = await coursesService.getAllCourses(
+        1,
+        100,
+        nameOrAcronym.trim() || undefined,
+      );
+
+      setCourses(response.data);
+    } catch (error) {
+      if (error instanceof Error) toast.error(error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!autoFetch) return;
+
+    fetchCourses();
+  }, []);
+
+  const getCourseById = async (id: string) => {
+    setIsLoading(true);
+
+    try {
+      return await coursesService.getById(id);
+    } catch (error) {
+      if (error instanceof Error) toast.error(error.message);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const createCourse = async (data: CoursePayload) => {
+    try {
+      await coursesService.createCourse(data);
+      toast.success("Curso cadastrado com sucesso!");
+      await fetchCourses();
+      return true;
+    } catch (error) {
+      if (error instanceof Error) toast.error(error.message);
+      return false;
+    }
+  };
+
+  const updateCourse = async (id: string, data: CoursePayload) => {
+    try {
+      await coursesService.updateCourse(id, data);
+      toast.success("Curso atualizado com sucesso!");
+      await fetchCourses();
+      return true;
+    } catch (error) {
+      if (error instanceof Error) toast.error(error.message);
+      return false;
+    }
+  };
+
+  const removeCourse = async (id: string) => {
+    try {
+      await coursesService.removeCourse(id);
+      toast.success("Curso excluído com sucesso do sistema");
+      await fetchCourses();
+      return true;
+    } catch (error) {
+      if (error instanceof Error) toast.error(error.message);
+      return false;
+    }
+  };
+
+  const orderedCourses = useMemo(() => {
+    return [...courses].sort((a, b) => a.name.localeCompare(b.name, "pt-BR"));
+  }, [courses]);
+
+  return {
+    courses: orderedCourses,
+    isLoading,
+    fetchCourses,
+    getCourseById,
+    createCourse,
+    updateCourse,
+    removeCourse,
+  };
+}

--- a/frontend/src/features/courses/hooks/useCoursesSettings.ts
+++ b/frontend/src/features/courses/hooks/useCoursesSettings.ts
@@ -19,7 +19,7 @@ export function useCoursesSettings(autoFetch = true) {
         nameOrAcronym.trim() || undefined,
       );
 
-      setCourses(response.data);
+      setCourses(response.items || []);
     } catch (error) {
       if (error instanceof Error) toast.error(error.message);
     } finally {

--- a/frontend/src/features/courses/services/courseService.ts
+++ b/frontend/src/features/courses/services/courseService.ts
@@ -1,19 +1,60 @@
 import api from "@/services/api";
-import { CourseFromBackend } from "../types/course";
+import {
+  Course,
+  CoursePayload,
+  CoursesResponse,
+  CreateCourseResponse,
+  UpdateCourseResponse,
+} from "../types/course";
 
 export const coursesService = {
-  async get(): Promise<CourseFromBackend[]> {
-    try {
-      const response = await api.get<CourseFromBackend[]>("/courses");
-      return response.data;
-    } catch {
-      return [
-        { id: "Engenharia de Software", name: "Engenharia de Software" },
-        { id: "Engenharia de Computação", name: "Engenharia de Computação" },
-        { id: "Ciência da Computação", name: "Ciência da Computação" },
-        { id: "ABI", name: "ABI" },
-        { id: "Outros", name: "Outros" },
-      ];
-    }
+  async getAllCourses(
+    page = 1,
+    limit = 20,
+    nameOrAcronym?: string,
+  ): Promise<CoursesResponse> {
+    const response = await api.get<CoursesResponse>("/courses", {
+      params: { page, limit, nameOrAcronym },
+      fallbackMsg: "Não foi possível carregar os cursos.",
+    });
+
+    return response.data;
+  },
+
+  async getById(id: string): Promise<Course> {
+    const response = await api.get<Course>(`/courses/${id}`, {
+      fallbackMsg: "Não foi possível carregar os detalhes do curso.",
+    });
+
+    return response.data;
+  },
+
+  async createCourse(data: CoursePayload): Promise<CreateCourseResponse> {
+    const response = await api.post<CreateCourseResponse>("/courses", data, {
+      fallbackMsg: "Não foi possível criar o curso.",
+    });
+
+    return response.data;
+  },
+
+  async updateCourse(
+    id: string,
+    data: CoursePayload,
+  ): Promise<UpdateCourseResponse> {
+    const response = await api.put<UpdateCourseResponse>(
+      `/courses/${id}`,
+      data,
+      {
+        fallbackMsg: "Não foi possível atualizar o curso.",
+      },
+    );
+
+    return response.data;
+  },
+
+  async removeCourse(id: string): Promise<void> {
+    await api.delete(`/courses/${id}`, {
+      fallbackMsg: "Não foi possível excluir o curso.",
+    });
   },
 };

--- a/frontend/src/features/courses/types/course.ts
+++ b/frontend/src/features/courses/types/course.ts
@@ -1,5 +1,5 @@
 export interface Course {
-  externalId: string;
+  id: string;
   name: string;
   acronym: string;
   coordinatorId?: string;
@@ -14,7 +14,6 @@ export interface CoursePayload {
   coordinatorId?: string;
 }
 
-// Rever no futuro essas duas interfaces Create e Update
 export interface CreateCourseResponse {
   externalId: string;
   name: string;
@@ -30,8 +29,8 @@ export interface UpdateCourseResponse {
 }
 
 export interface CoursesResponse {
-  data: Course[];
-  page: number;
-  limit: number;
-  total: number;
+  totalPages: number;
+  currentPage: number;
+  totalItems: number;
+  items: Course[];
 }

--- a/frontend/src/features/courses/types/course.ts
+++ b/frontend/src/features/courses/types/course.ts
@@ -1,4 +1,37 @@
-export interface CourseFromBackend {
-  id: string;
+export interface Course {
+  externalId: string;
   name: string;
+  acronym: string;
+  coordinatorId?: string;
+  coordinatorName?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CoursePayload {
+  name: string;
+  acronym: string;
+  coordinatorId?: string;
+}
+
+// Rever no futuro essas duas interfaces Create e Update
+export interface CreateCourseResponse {
+  externalId: string;
+  name: string;
+  acronym: string;
+  coordinatorId?: string;
+}
+
+export interface UpdateCourseResponse {
+  externalId: string;
+  name: string;
+  acronym: string;
+  coordinatorId?: string;
+}
+
+export interface CoursesResponse {
+  data: Course[];
+  page: number;
+  limit: number;
+  total: number;
 }

--- a/frontend/src/features/students/components/form/StudentForm.tsx
+++ b/frontend/src/features/students/components/form/StudentForm.tsx
@@ -83,8 +83,8 @@ export default function StudentForm({
 
       const payload = formatForBackend(formData);
 
-      if (isEditMode && initialData?.externalId) {
-        await studentService.updateStudent(initialData.externalId, payload);
+      if (isEditMode && initialData?.id) {
+        await studentService.updateStudent(initialData.id, payload);
         toast.success("Estudante atualizado com sucesso!");
       } else {
         await studentService.createStudent(payload as StudentFormData);

--- a/frontend/src/features/students/components/profile/StudentFooter.tsx
+++ b/frontend/src/features/students/components/profile/StudentFooter.tsx
@@ -20,7 +20,7 @@ export default function StudentFooter({ student }: StudentFooterProps) {
 
   const handleDisableStudent = async () => {
     try {
-      await studentService.deleteStudent(student.externalId);
+      await studentService.deleteStudent(student.id);
       toast.success(
         !student.removed
           ? "Aluno inativado com sucesso."
@@ -58,7 +58,7 @@ export default function StudentFooter({ student }: StudentFooterProps) {
           <CommonButton
             label="Editar Aluno"
             onClick={() =>
-              handleNavigation({ path: PATHS.edit_student(student.externalId) })
+              handleNavigation({ path: PATHS.edit_student(student.id) })
             }
             endIcon={UserPen}
             sizeIcon={20}
@@ -87,7 +87,7 @@ export default function StudentFooter({ student }: StudentFooterProps) {
               endIcon={Plus}
               onClick={() =>
                 handleNavigation({
-                  path: PATHS.register_attendance(student.externalId),
+                  path: PATHS.register_attendance(student.id),
                 })
               }
               className="bg-[#6bc4a6] text-white hover:bg-[#52b594] text-sm font-semibold"

--- a/frontend/src/features/students/components/table/StudentTable.tsx
+++ b/frontend/src/features/students/components/table/StudentTable.tsx
@@ -107,13 +107,13 @@ export default function StudentTable() {
       renderCell: (student) => (
         <div className="flex justify-center gap-0.5">
           <Link
-            href={PATHS.visualize_student(student.externalId)}
+            href={PATHS.visualize_student(student.id)}
             className="flex items-center rounded-md p-1 text-[#6bc4a6] hover:bg-[#e8f7f2]"
           >
             <Eye size={20} />
           </Link>
           <Link
-            href={PATHS.edit_student(student.externalId)}
+            href={PATHS.edit_student(student.id)}
             className="flex items-center rounded-md p-1 text-[#b0a898] hover:bg-[#f0ebe0]"
           >
             <Edit size={20} />

--- a/frontend/src/features/students/types/student.ts
+++ b/frontend/src/features/students/types/student.ts
@@ -1,6 +1,7 @@
+import { Attendance } from "@/features/attendances/types/attendance";
+
 export interface Student {
-  internalId: number;
-  externalId: string;
+  id: string;
   enrollmentId: string;
   name: string;
   email: string;
@@ -13,10 +14,11 @@ export interface Student {
   updatedAt: string;
   removed: boolean;
   course: string;
+  lastAttendance: Attendance;
 }
 
 export interface StudentFormData {
-  externalId: string;
+  id: string;
   enrollmentId: string;
   name: string;
   dtBirth: string;

--- a/frontend/src/features/students/utils/studentUtils.ts
+++ b/frontend/src/features/students/utils/studentUtils.ts
@@ -2,7 +2,7 @@ import { formatDate, maskPhone, maskRegistration } from "@/utils/utils";
 import { FormErrors, Student, StudentFormData } from "../types/student";
 
 export const EMPTY_FORM_STUDENT: StudentFormData = {
-  externalId: "",
+  id: "",
   enrollmentId: "",
   name: "",
   dtBirth: "",
@@ -34,7 +34,7 @@ export const validateStudentForm = (data: StudentFormData): FormErrors => {
 export const formatForBackend = (data: StudentFormData) => {
   const [day, month, year] = data.dtBirth.split("/");
 
-  const { externalId, ...restData } = data;
+  const { id: externalId, ...restData } = data;
 
   return {
     ...restData,


### PR DESCRIPTION
Nessa branch foi implementada o CRUD de cursos. Pontos importantes:

- As rotas retornam `/courses`.
- Ajustados os types, service e hook de cursos.
- Por enquanto deixei o hook de cursos mockado.
- Na feature de `remove` ter cuidado já que o contrato da rota não foi explicitamente divulgado, segui um contrato baseado no critério de avaliação.

Status:  `409 Conflito`
```json
{
  "message": "Não é possível excluir este curso pois existem 20 alunos vinculados a ele. Altere o curso desses alunos antes de prosseguir com a exclusão.",
  "studentsCount": 20
}
```