### PR TITLE
refact: new pedagogue and professor atributes

### DIFF
--- a/backend/prisma/migrations/20260520203708_approved_enabled_atributes_professor_pedagogue/migration.sql
+++ b/backend/prisma/migrations/20260520203708_approved_enabled_atributes_professor_pedagogue/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "Pedagogue" ADD COLUMN     "approved" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Professor" ADD COLUMN     "approved" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -42,6 +42,9 @@ model Pedagogue {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
+  approved Boolean @default(false)
+  enabled  Boolean @default(false)
+
   attendances Attendance[]
   reports     Report[]
 }
@@ -56,6 +59,9 @@ model Professor {
   removed      Boolean  @default(false)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+
+  approved Boolean @default(false)
+  enabled  Boolean @default(false)
 
   feedbacks          Feedback[]
   classProfessors    ClassProfessor[]

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,15 +32,18 @@ model Student {
 }
 
 model Pedagogue {
-  internalId   Int      @id @default(autoincrement())
-  externalId   String   @unique
-  registration String   @unique
+  internalId Int    @id @default(autoincrement())
+  externalId String @unique
+
+  registration String  @unique
   name         String
-  email        String   @unique
+  email        String  @unique
+  password     String
   phoneNumber  String?
-  removed      Boolean  @default(false)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+
+  removed   Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   approved Boolean @default(false)
   enabled  Boolean @default(false)
@@ -50,15 +53,18 @@ model Pedagogue {
 }
 
 model Professor {
-  internalId   Int      @id @default(autoincrement())
-  externalId   String   @unique
-  registration String   @unique
+  internalId Int    @id @default(autoincrement())
+  externalId String @unique
+
+  registration String  @unique
   name         String
-  email        String   @unique
+  email        String  @unique
+  password     String
   phoneNumber  String?
-  removed      Boolean  @default(false)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+
+  removed   Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   approved Boolean @default(false)
   enabled  Boolean @default(false)


### PR DESCRIPTION
# Descrição

Adiciona novos atributos relacionados à habilitação/aprovação de usuários dos tipos `Professor` e `Pedagogue`, permitindo identificar se o usuário já está habilitado no sistema.

---

# Alterações Realizadas

## Banco de Dados

* Atualização do schema Prisma
* Adição dos novos atributos de habilitação/aprovação para:

  * `Professor`
  * `Pedagogue`
* Criação de migration para refletir as alterações no banco

---

# Backend

* Atualização das entidades relacionadas
* Ajuste dos DTOs para suportar os novos atributos
* Adequação dos fluxos de criação e atualização
* Ajuste das validações relacionadas aos tipos de usuário

---

# Objetivo

Permitir que o sistema identifique diretamente no cadastro específico de cada usuário se ele já está habilitado/aprovado, evitando dependência de verificações externas e simplificando a lógica de autenticação/autorização.

---

# Observações

* Necessário executar as migrations antes de utilizar a funcionalidade
* Alteração compatível com a estrutura atual de autenticação

---

# Como testar

1. Executar as migrations:

   ```bash
   npx prisma migrate dev
   ```

2. Criar ou atualizar usuários dos tipos:

   * Professor
   * Pedagogo

3. Validar se os novos atributos:

   * são persistidos corretamente
   * retornam corretamente nas consultas
   * funcionam nos fluxos de habilitação
