### PR TITLE
feat: implement schedule and schedule slot models with status management

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,6 +21,13 @@ enum UserStatus {
   DISABLED
 }
 
+enum ScheduleSlotStatus {
+  AVAILABLE
+  PENDING
+  BOOKED
+  CANCELLED
+}
+
 model Student {
   internalId   Int      @id @default(autoincrement())
   externalId   String   @unique
@@ -79,6 +86,7 @@ model Pedagogue {
 
   attendances Attendance[]
   reports     Report[]
+  schedules   Schedule[]
 }
 
 model Professor {
@@ -121,6 +129,8 @@ model Attendance {
   student   Student        @relation(fields: [studentId], references: [internalId])
   pedagogue Pedagogue?     @relation(fields: [pedagogueId], references: [internalId])
   type      AttendanceType @relation(fields: [typeId], references: [internalId])
+
+  scheduleSlots ScheduleSlot[]
 }
 
 model AttendanceType {
@@ -280,4 +290,40 @@ model ClassProfessor {
   class     ClassOffering @relation(fields: [classId], references: [internalId])
 
   @@id([professorId, classId])
+}
+
+model Schedule {
+  internalId Int    @id @default(autoincrement())
+  externalId String @unique
+
+  pedagogueId Int
+  pedagogue   Pedagogue @relation(fields: [pedagogueId], references: [internalId])
+
+  startDate DateTime
+  endDate   DateTime
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  removed   Boolean  @default(false)
+
+  slots ScheduleSlot[]
+}
+
+model ScheduleSlot {
+  internalId Int    @id @default(autoincrement())
+  externalId String @unique
+
+  scheduleId Int
+  schedule   Schedule @relation(fields: [scheduleId], references: [internalId])
+
+  startDateTime DateTime
+  endDateTime   DateTime
+
+  status ScheduleSlotStatus @default(AVAILABLE)
+
+  attendanceId Int?
+  attendance   Attendance? @relation(fields: [attendanceId], references: [internalId])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/backend/src/domain/entities/schedule.ts
+++ b/backend/src/domain/entities/schedule.ts
@@ -1,0 +1,68 @@
+import { Result } from "@domain/shared/result";
+
+import { DateInput, DateVO } from "../valueObjects/shared/date";
+import { ExternalIdVO } from "../valueObjects/shared/externalId";
+
+export type ScheduleProps = {
+  id?: string;
+  pedagogueId: string;
+  startDate: DateInput;
+  endDate: DateInput;
+  removed?: boolean;
+};
+
+export class Schedule {
+  constructor(
+    public readonly id: ExternalIdVO,
+    public readonly pedagogueId: ExternalIdVO,
+    public startDate: DateVO,
+    public endDate: DateVO,
+    private _removed: boolean = false,
+  ) {}
+
+  static create(props: ScheduleProps): Result<Schedule> {
+    const externalId = ExternalIdVO.create();
+    const pedagogueId = ExternalIdVO.from(props.pedagogueId);
+    const startDate = DateVO.create(props.startDate);
+    const endDate = DateVO.create(props.endDate);
+
+    const results = [externalId, pedagogueId, startDate, endDate];
+
+    for (const result of results) {
+      if (result?.isFailure) {
+        return Result.fail<Schedule>(result.error!);
+      }
+    }
+
+    return Result.ok<Schedule>(
+      new Schedule(
+        externalId.getValue(),
+        pedagogueId.getValue(),
+        startDate.getValue(),
+        endDate.getValue(),
+        props.removed ?? false,
+      ),
+    );
+  }
+
+  static rehydrate(props: ScheduleProps): Schedule {
+    return new Schedule(
+      ExternalIdVO.fromTrusted(props.id!),
+      ExternalIdVO.fromTrusted(props.pedagogueId),
+      DateVO.fromTrusted(new Date(props.startDate as string | Date)),
+      DateVO.fromTrusted(new Date(props.endDate as string | Date)),
+      props.removed ?? false,
+    );
+  }
+
+  remove(): void {
+    if (this._removed) {
+      throw new Error(`${Schedule.name}:${this.id} is already removed`);
+    }
+    this._removed = true;
+  }
+
+  get removed(): boolean {
+    return this._removed;
+  }
+}

--- a/backend/src/domain/entities/scheduleSlot.ts
+++ b/backend/src/domain/entities/scheduleSlot.ts
@@ -1,0 +1,63 @@
+import { Result } from "@domain/shared/result";
+
+import { ScheduleSlotStatusEnum } from "../enum/scheduleSlotStatus";
+import { DateInput, DateVO } from "../valueObjects/shared/date";
+import { ExternalIdVO } from "../valueObjects/shared/externalId";
+
+export type ScheduleSlotProps = {
+  id?: string;
+  scheduleId: string;
+  startDateTime: DateInput;
+  endDateTime: DateInput;
+  status: ScheduleSlotStatusEnum;
+  attendanceId?: string;
+};
+
+export class ScheduleSlot {
+  constructor(
+    public readonly id: ExternalIdVO,
+    public readonly scheduleId: ExternalIdVO,
+    public startDateTime: DateVO,
+    public endDateTime: DateVO,
+    public status: ScheduleSlotStatusEnum,
+    public attendanceId?: ExternalIdVO,
+  ) {}
+
+  static create(props: ScheduleSlotProps): Result<ScheduleSlot> {
+    const externalId = ExternalIdVO.create();
+    const scheduleId = ExternalIdVO.from(props.scheduleId);
+    const startDateTime = DateVO.create(props.startDateTime);
+    const endDateTime = DateVO.create(props.endDateTime);
+    const attendanceId = props.attendanceId ? ExternalIdVO.from(props.attendanceId) : undefined;
+
+    const results = [externalId, scheduleId, startDateTime, endDateTime, attendanceId];
+
+    for (const result of results) {
+      if (result?.isFailure) {
+        return Result.fail<ScheduleSlot>(result.error!);
+      }
+    }
+
+    return Result.ok<ScheduleSlot>(
+      new ScheduleSlot(
+        externalId.getValue(),
+        scheduleId.getValue(),
+        startDateTime.getValue(),
+        endDateTime.getValue(),
+        props.status,
+        attendanceId?.getValue() ?? undefined,
+      ),
+    );
+  }
+
+  static rehydrate(props: ScheduleSlotProps): ScheduleSlot {
+    return new ScheduleSlot(
+      ExternalIdVO.fromTrusted(props.id!),
+      ExternalIdVO.fromTrusted(props.scheduleId),
+      DateVO.fromTrusted(new Date(props.startDateTime as string | Date)),
+      DateVO.fromTrusted(new Date(props.endDateTime as string | Date)),
+      props.status,
+      props.attendanceId ? ExternalIdVO.fromTrusted(props.attendanceId) : undefined,
+    );
+  }
+}

--- a/backend/src/domain/enum/scheduleSlotStatus.ts
+++ b/backend/src/domain/enum/scheduleSlotStatus.ts
@@ -1,0 +1,6 @@
+export enum ScheduleSlotStatusEnum {
+  AVAILABLE = "AVAILABLE",
+  PENDING = "PENDING",
+  BOOKED = "BOOKED",
+  CANCELLED = "CANCELLED",
+}


### PR DESCRIPTION
# feat: implementar modelos Schedule e ScheduleSlot

## Alterações realizadas

### Banco de Dados (Prisma)

- Adicionado o enum `ScheduleSlotStatus`.
- Criado o modelo `Schedule`.
- Criado o modelo `ScheduleSlot`.
- Atualizados os modelos `Pedagogue` e `Attendance` com os novos relacionamentos.

### Camada de Domínio

- Criado o enum `ScheduleSlotStatusEnum`.
- Criada a entidade `Schedule`.
- Criada a entidade `ScheduleSlot`.

## Validação

- Schema Prisma validado com sucesso utilizando:

```bash
npx prisma validate
```

## Issue Relacionada

Closes #388