### PR TITLE
fix(task-385): adjusting the display of validation messages in the account register

### DIFF
--- a/frontend/src/features/register/components/form/PasswordRequirements.tsx
+++ b/frontend/src/features/register/components/form/PasswordRequirements.tsx
@@ -1,0 +1,37 @@
+import { CircleCheck, CircleX } from "lucide-react";
+
+import { passwordRequirements } from "../../utils/passwordRequirements";
+
+interface PasswordRequirementsProps {
+  password: string;
+}
+
+export function PasswordRequirements({ password }: PasswordRequirementsProps) {
+  return (
+    <ul
+      id="password-requirements"
+      className="mt-1 flex flex-col gap-1"
+      aria-label="Requisitos da senha"
+    >
+      {passwordRequirements.map(({ id, label, validate }) => {
+        const isMet = validate(password);
+
+        return (
+          <li
+            key={id}
+            className={`flex items-center gap-1.5 text-xs ${
+              isMet ? "text-green-600" : "text-red-600"
+            }`}
+          >
+            {isMet ? (
+              <CircleCheck size={14} aria-hidden="true" />
+            ) : (
+              <CircleX size={14} aria-hidden="true" />
+            )}
+            <span>{label}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/src/features/register/components/form/RegisterForm.tsx
+++ b/frontend/src/features/register/components/form/RegisterForm.tsx
@@ -2,6 +2,7 @@
 
 import { MailCheck } from "lucide-react";
 import Image from "next/image";
+import { useWatch } from "react-hook-form";
 
 import { Images } from "@/assets";
 import CommonButton from "@/components/ui/CommonButton";
@@ -10,6 +11,7 @@ import { PATHS } from "@/constants/paths";
 import { useAppNavigation } from "@/utils/navigator";
 import { maskPhone } from "@/utils/utils";
 import { useRegister } from "../../hooks/useRegister";
+import { PasswordRequirements } from "./PasswordRequirements";
 
 export default function RegisterForm() {
   const { handleNavigation } = useAppNavigation();
@@ -24,8 +26,14 @@ export default function RegisterForm() {
   } = useRegister();
   const {
     register,
+    control,
     formState: { errors },
   } = form;
+  const password = useWatch({
+    control,
+    name: "password",
+    defaultValue: "",
+  });
 
   const baseInputClass =
     "w-full px-3.5 py-2.5 border-[1.5px] rounded-md bg-white text-sm text-stone-800 outline-none transition-colors font-sans";
@@ -175,14 +183,19 @@ export default function RegisterForm() {
               />
             </Field>
 
-            <Field label="Senha:" error={errors.password?.message} required>
+            <Field label="Senha:" required>
               <input
                 type="password"
                 placeholder="••••••••"
                 {...register("password")}
                 className={getValidationClass(!!errors.password)}
                 aria-label="Senha"
+                aria-describedby="password-requirements"
+                aria-invalid={!!errors.password}
               />
+              {password.trim().length > 0 && (
+                <PasswordRequirements password={password} />
+              )}
             </Field>
 
             <Field

--- a/frontend/src/features/register/hooks/useRegister.ts
+++ b/frontend/src/features/register/hooks/useRegister.ts
@@ -28,6 +28,8 @@ export const useRegister = () => {
 
   const form = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
+    mode: "onBlur",
+    reValidateMode: "onChange",
     defaultValues: {
       name: "",
       registrationNumber: "",

--- a/frontend/src/features/register/utils/passwordRequirements.ts
+++ b/frontend/src/features/register/utils/passwordRequirements.ts
@@ -1,0 +1,43 @@
+export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_MAX_LENGTH = 128;
+
+export const passwordPatterns = {
+  uppercase: /[A-Z]/,
+  lowercase: /[a-z]/,
+  number: /[0-9]/,
+  specialCharacter: /[^a-zA-Z0-9]/,
+};
+
+export const passwordRequirements = [
+  {
+    id: "length",
+    label: `Entre ${PASSWORD_MIN_LENGTH} e ${PASSWORD_MAX_LENGTH} caracteres`,
+    validate: (password: string) =>
+      password.trim().length >= PASSWORD_MIN_LENGTH &&
+      password.trim().length <= PASSWORD_MAX_LENGTH,
+  },
+  {
+    id: "uppercase",
+    label: "Uma letra maiúscula",
+    validate: (password: string) =>
+      passwordPatterns.uppercase.test(password.trim()),
+  },
+  {
+    id: "lowercase",
+    label: "Uma letra minúscula",
+    validate: (password: string) =>
+      passwordPatterns.lowercase.test(password.trim()),
+  },
+  {
+    id: "number",
+    label: "Um número",
+    validate: (password: string) =>
+      passwordPatterns.number.test(password.trim()),
+  },
+  {
+    id: "special-character",
+    label: "Um caractere especial",
+    validate: (password: string) =>
+      passwordPatterns.specialCharacter.test(password.trim()),
+  },
+];

--- a/frontend/src/features/register/utils/validations.ts
+++ b/frontend/src/features/register/utils/validations.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  passwordPatterns,
+} from "./passwordRequirements";
+
 export const registerSchema = z
   .object({
     name: z
@@ -44,12 +50,23 @@ export const registerSchema = z
       .string()
       .trim()
       .nonempty({ message: "A senha é obrigatória." })
-      .min(8, { message: "A senha deve ter no mínimo 8 caracteres." })
-      .regex(/[A-Z]/, "Deve conter ao menos uma letra maiúscula.")
-      .regex(/[a-z]/, "Deve conter ao menos uma letra minúscula.")
-      .regex(/[0-9]/, "Deve conter ao menos um número.")
+      .min(PASSWORD_MIN_LENGTH, {
+        message: `A senha deve ter no mínimo ${PASSWORD_MIN_LENGTH} caracteres.`,
+      })
+      .max(PASSWORD_MAX_LENGTH, {
+        message: `A senha deve ter no máximo ${PASSWORD_MAX_LENGTH} caracteres.`,
+      })
       .regex(
-        /[^a-zA-Z0-9]/,
+        passwordPatterns.uppercase,
+        "Deve conter ao menos uma letra maiúscula.",
+      )
+      .regex(
+        passwordPatterns.lowercase,
+        "Deve conter ao menos uma letra minúscula.",
+      )
+      .regex(passwordPatterns.number, "Deve conter ao menos um número.")
+      .regex(
+        passwordPatterns.specialCharacter,
         "Deve conter ao menos um caractere especial (@, #, $, etc).",
       ),
 


### PR DESCRIPTION
Nessa branch foi solucionado um BUG (#385) reportado sobre a validação dos campos da página `/register`.

Pontos importantes:
- Criado um checklist que apresenta simultaneamente todos os requisitos da senha.
- O checklist aparece somente após o usuário começar a digitar.
- A mensagem sequencial de senha foi removida, evitando os erros em cascata quando apertava em criar conta.
- O formulário passou a validar os campos ao perderem o foco com `onBlur`. Após um erro, o campo é revalidado durante a correção com `onChange`.

