### PR TITLE
feat: adding the function for the pedagogue to choose the role of new users

### DIFF
--- a/frontend/src/features/users/components/ApproveAccountRequestModal.tsx
+++ b/frontend/src/features/users/components/ApproveAccountRequestModal.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import CommonButton from "@/components/ui/CommonButton";
+
+import { ApprovalRole, PendingAccountRequestItem } from "../types/user";
+
+interface ApproveAccountRequestModalProps {
+  request: PendingAccountRequestItem;
+  isLoading: boolean;
+  onClose: () => void;
+  onConfirm: (role: ApprovalRole) => void;
+}
+
+const roleOptions: {
+  value: ApprovalRole;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "PROFESSOR",
+    label: "Professor(a)",
+    description: "Tem acesso aos relatórios dos alunos vinculados a ele.",
+  },
+  {
+    value: "PEDAGOGUE",
+    label: "Pedagogo(a)",
+    description: "Tem acesso às funcionalidades de administrador do sistema.",
+  },
+];
+
+export default function ApproveAccountRequestModal({
+  request,
+  isLoading,
+  onClose,
+  onConfirm,
+}: ApproveAccountRequestModalProps) {
+  const [selectedRole, setSelectedRole] = useState<ApprovalRole>("PROFESSOR");
+
+  const selectedRoleLabel = roleOptions.find(
+    (option) => option.value === selectedRole,
+  )?.label;
+
+  const handleClose = () => {
+    if (!isLoading) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-1000 flex items-center justify-center bg-black/40 p-4"
+      onClick={handleClose}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="approve-account-request-title"
+        className="w-full max-w-2xl rounded-2xl border border-[#ece7db] bg-[#faf7f0] p-6 shadow-[0_8px_40px_rgba(0,0,0,0.18)] sm:p-8"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2
+          id="approve-account-request-title"
+          className="text-center text-2xl font-extrabold text-[#3a3530]"
+        >
+          Aprovar usuário
+        </h2>
+
+        <p className="mt-2 text-center text-sm text-[#6a6560]">
+          Selecione o papel do usuário no sistema:
+        </p>
+
+        <fieldset className="mt-6 flex flex-col gap-3" disabled={isLoading}>
+          <legend className="sr-only">Papel do usuário</legend>
+
+          {roleOptions.map((option) => {
+            const isSelected = selectedRole === option.value;
+
+            return (
+              <label
+                key={option.value}
+                className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-3 transition-colors ${
+                  isSelected
+                    ? "border-[#6bc4a6] bg-emerald-50"
+                    : "border-[#d8e4e8] bg-[#eaf5f8] hover:border-[#9bcfbd]"
+                } ${isLoading ? "cursor-not-allowed opacity-70" : ""}`}
+              >
+                <input
+                  type="radio"
+                  name="approval-role"
+                  value={option.value}
+                  checked={isSelected}
+                  onChange={() => setSelectedRole(option.value)}
+                  className="mt-1 h-4 w-4 accent-[#52b594]"
+                />
+
+                <span className="text-sm leading-5 text-[#4a4540]">
+                  <strong>{option.label}:</strong> {option.description}
+                </span>
+              </label>
+            );
+          })}
+        </fieldset>
+
+        <p className="mx-auto mt-7 max-w-xl text-center text-base leading-6 text-[#4a4540]">
+          Você tem certeza que deseja aprovar <strong>{request.name}</strong>{" "}
+          para o papel de <strong>{selectedRoleLabel}</strong>?
+        </p>
+
+        <div className="mt-7 flex flex-col-reverse justify-center gap-3 sm:flex-row">
+          <CommonButton
+            type="button"
+            label="Voltar"
+            onClick={handleClose}
+            disabled={isLoading}
+            className="min-w-40 justify-center border border-[#ef9c8d] bg-[#f4a598] text-white hover:bg-[#ef9c8d] disabled:cursor-not-allowed disabled:opacity-60"
+          />
+
+          <CommonButton
+            type="button"
+            label={isLoading ? "Aprovando..." : "Aprovar"}
+            startIcon={isLoading ? Loader2 : undefined}
+            onClick={() => onConfirm(selectedRole)}
+            disabled={isLoading}
+            className="min-w-40 justify-center disabled:cursor-not-allowed disabled:opacity-60 [&_svg]:animate-spin"
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/users/components/ApproveAccountRequestModal.tsx
+++ b/frontend/src/features/users/components/ApproveAccountRequestModal.tsx
@@ -5,17 +5,17 @@ import { useState } from "react";
 
 import CommonButton from "@/components/ui/CommonButton";
 
-import { ApprovalRole, PendingAccountRequestItem } from "../types/user";
+import { PendingAccountRequestItem, UserRole } from "../types/user";
 
 interface ApproveAccountRequestModalProps {
   request: PendingAccountRequestItem;
   isLoading: boolean;
   onClose: () => void;
-  onConfirm: (role: ApprovalRole) => void;
+  onConfirm: (role: UserRole) => void;
 }
 
 const roleOptions: {
-  value: ApprovalRole;
+  value: UserRole;
   label: string;
   description: string;
 }[] = [
@@ -37,7 +37,7 @@ export default function ApproveAccountRequestModal({
   onClose,
   onConfirm,
 }: ApproveAccountRequestModalProps) {
-  const [selectedRole, setSelectedRole] = useState<ApprovalRole>("PROFESSOR");
+  const [selectedRole, setSelectedRole] = useState<UserRole>("PROFESSOR");
 
   const selectedRoleLabel = roleOptions.find(
     (option) => option.value === selectedRole,

--- a/frontend/src/features/users/components/table/PendingRequestsColumns.tsx
+++ b/frontend/src/features/users/components/table/PendingRequestsColumns.tsx
@@ -21,7 +21,7 @@ export function getPendingRequestsColumns({
   onNameFilterChange: (value: string) => void;
   emailFilter: string;
   onEmailFilterChange: (value: string) => void;
-  onApprove: (id: string, role?: string) => void;
+  onApprove: (request: PendingAccountRequestItem) => void;
   onReject: (id: string) => void;
   processingAction: { id: string; action: PendingRequestAction } | null;
 }): Column<PendingAccountRequestItem>[] {
@@ -77,7 +77,8 @@ export function getPendingRequestsColumns({
         return (
           <div className="flex items-center justify-center gap-2">
             <button
-              onClick={() => onApprove(request.id, request.role)}
+              type="button"
+              onClick={() => onApprove(request)}
               disabled={isProcessing}
               className="flex cursor-pointer h-8 min-w-24 items-center justify-center gap-1.5 rounded-md bg-emerald-50 px-3 py-1 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-60"
               title="Aprovar"
@@ -90,6 +91,7 @@ export function getPendingRequestsColumns({
               {isApproving ? "Aprovando" : "Aprovar"}
             </button>
             <button
+              type="button"
               onClick={() => onReject(request.id)}
               disabled={isProcessing}
               className="flex cursor-pointer h-8 min-w-24 items-center justify-center gap-1.5 rounded-md bg-red-50 px-3 py-1 text-sm font-medium text-red-500 transition-colors hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-60"

--- a/frontend/src/features/users/components/table/PendingRequestsTable.tsx
+++ b/frontend/src/features/users/components/table/PendingRequestsTable.tsx
@@ -7,10 +7,7 @@ import { DataTable } from "@/components/ui/DataTable";
 import ApproveAccountRequestModal from "../ApproveAccountRequestModal";
 import { useApproveAccountRequest } from "../../hooks/useApproveAccountRequest";
 import { usePendingAccountRequests } from "../../hooks/usePendingAccountRequests";
-import {
-  ApprovalRole,
-  PendingAccountRequestItem,
-} from "../../types/user";
+import { PendingAccountRequestItem, UserRole } from "../../types/user";
 import {
   getPendingRequestsColumns,
   PendingRequestAction,
@@ -81,7 +78,7 @@ export default function PendingRequestsTable() {
     setRequestToApprove(request);
   };
 
-  const handleApprove = async (role: ApprovalRole) => {
+  const handleApprove = async (role: UserRole) => {
     if (!requestToApprove) return;
 
     const requestId = requestToApprove.id;

--- a/frontend/src/features/users/components/table/PendingRequestsTable.tsx
+++ b/frontend/src/features/users/components/table/PendingRequestsTable.tsx
@@ -4,8 +4,13 @@ import { useEffect, useMemo, useState } from "react";
 
 import { DataTable } from "@/components/ui/DataTable";
 
+import ApproveAccountRequestModal from "../ApproveAccountRequestModal";
 import { useApproveAccountRequest } from "../../hooks/useApproveAccountRequest";
 import { usePendingAccountRequests } from "../../hooks/usePendingAccountRequests";
+import {
+  ApprovalRole,
+  PendingAccountRequestItem,
+} from "../../types/user";
 import {
   getPendingRequestsColumns,
   PendingRequestAction,
@@ -17,6 +22,8 @@ export default function PendingRequestsTable() {
   const [nameFilter, setNameFilter] = useState("");
   const [emailFilter, setEmailFilter] = useState("");
   const [debouncedNameFilter, setDebouncedNameFilter] = useState("");
+  const [requestToApprove, setRequestToApprove] =
+    useState<PendingAccountRequestItem | null>(null);
   const [processingAction, setProcessingAction] = useState<{
     id: string;
     action: PendingRequestAction;
@@ -70,14 +77,22 @@ export default function PendingRequestsTable() {
     });
   };
 
-  const handleApprove = async (id: string, role?: string) => {
-    setProcessingAction({ id, action: "approve" });
+  const handleOpenApprovalModal = (request: PendingAccountRequestItem) => {
+    setRequestToApprove(request);
+  };
 
-    const wasApproved = await approveRequest(id, true, role || "PROFESSOR");
+  const handleApprove = async (role: ApprovalRole) => {
+    if (!requestToApprove) return;
+
+    const requestId = requestToApprove.id;
+    setProcessingAction({ id: requestId, action: "approve" });
+
+    const wasApproved = await approveRequest(requestId, true, role);
 
     if (wasApproved) {
-      removeRequest(id);
+      removeRequest(requestId);
       adjustPageAfterRemoval();
+      setRequestToApprove(null);
     }
 
     setProcessingAction(null);
@@ -106,24 +121,39 @@ export default function PendingRequestsTable() {
     onNameFilterChange: handleNameFilterChange,
     emailFilter,
     onEmailFilterChange: handleEmailFilterChange,
-    onApprove: handleApprove,
+    onApprove: handleOpenApprovalModal,
     onReject: handleReject,
     processingAction,
   });
 
+  const isApproving =
+    processingAction?.id === requestToApprove?.id &&
+    processingAction?.action === "approve";
+
   return (
-    <DataTable
-      title="Solicitações Pendentes"
-      isLoading={isLoading}
-      data={paginatedRequests}
-      columns={columns}
-      page={page}
-      setPage={setPage}
-      limit={limit}
-      setLimit={setLimit}
-      totalItems={totalItems}
-      totalPages={totalPages}
-      emptyMessage="Nenhuma solicitação pendente encontrada."
-    />
+    <>
+      <DataTable
+        title="Solicitações Pendentes"
+        isLoading={isLoading}
+        data={paginatedRequests}
+        columns={columns}
+        page={page}
+        setPage={setPage}
+        limit={limit}
+        setLimit={setLimit}
+        totalItems={totalItems}
+        totalPages={totalPages}
+        emptyMessage="Nenhuma solicitação pendente encontrada."
+      />
+
+      {requestToApprove && (
+        <ApproveAccountRequestModal
+          request={requestToApprove}
+          isLoading={isApproving}
+          onClose={() => setRequestToApprove(null)}
+          onConfirm={handleApprove}
+        />
+      )}
+    </>
   );
 }

--- a/frontend/src/features/users/components/table/UserTableColumns.tsx
+++ b/frontend/src/features/users/components/table/UserTableColumns.tsx
@@ -6,7 +6,7 @@ import { SearchInput } from "@/components/ui/SearchInput";
 
 import { UserRole, UserStatus, UserStatusFilter } from "../../types/user";
 
-const roleLabelMap: Record<string, string> = {
+const roleLabelMap: Record<UserRole, string> = {
   PEDAGOGUE: "Pedagoga",
   PROFESSOR: "Professor",
 };
@@ -22,8 +22,8 @@ const statusLabelMap: Record<string, string> = {
 export const formatStatus = (status: string) =>
   statusLabelMap[status] ?? status;
 
-export const formatRole = (role?: string) =>
-  roleLabelMap[role ?? ""] ?? role ?? "";
+export const formatRole = (role?: UserRole) =>
+  role ? roleLabelMap[role] : "";
 
 export function StatusBadge({ status }: { status: UserStatus }) {
   const isActive = status === "ENABLED" || status === "APPROVED";

--- a/frontend/src/features/users/hooks/useApproveAccountRequest.ts
+++ b/frontend/src/features/users/hooks/useApproveAccountRequest.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import toast from "react-hot-toast";
 
 import { accountRequestService } from "../services/accountRequestService";
+import { UserRole } from "../types/user";
 
 interface UseApproveAccountRequestOptions {
   onSuccess?: () => void;
@@ -15,7 +16,7 @@ export const useApproveAccountRequest = (
   const approveRequest = async (
     id: string,
     isApproved: boolean,
-    role?: string,
+    role?: UserRole,
   ) => {
     try {
       setIsLoading(true);

--- a/frontend/src/features/users/services/accountRequestService.ts
+++ b/frontend/src/features/users/services/accountRequestService.ts
@@ -1,6 +1,6 @@
 import api from "@/services/api";
 
-import { PendingAccountRequestItem } from "../types/user";
+import { PendingAccountRequestItem, UserRole } from "../types/user";
 
 export const accountRequestService = {
   async getPendingAccountRequests(): Promise<PendingAccountRequestItem[]> {
@@ -14,7 +14,11 @@ export const accountRequestService = {
     return response.data;
   },
 
-  async approveAccountRequest(id: string, isApproved: boolean, role?: string): Promise<void> {
+  async approveAccountRequest(
+    id: string,
+    isApproved: boolean,
+    role?: UserRole,
+  ): Promise<void> {
     await api.post(
       "/account-requests/approve-users",
       { id, isApproved, role },

--- a/frontend/src/features/users/types/user.ts
+++ b/frontend/src/features/users/types/user.ts
@@ -1,5 +1,7 @@
 export type UserRole = "PEDAGOGUE" | "PROFESSOR" | string;
 
+export type ApprovalRole = "PEDAGOGUE" | "PROFESSOR";
+
 export type UserStatus =
   | "ENABLED"
   | "DISABLED"

--- a/frontend/src/features/users/types/user.ts
+++ b/frontend/src/features/users/types/user.ts
@@ -1,6 +1,4 @@
-export type UserRole = "PEDAGOGUE" | "PROFESSOR" | string;
-
-export type ApprovalRole = "PEDAGOGUE" | "PROFESSOR";
+export type UserRole = "PEDAGOGUE" | "PROFESSOR";
 
 export type UserStatus =
   | "ENABLED"


### PR DESCRIPTION
Nessa branch foi implementada a funcionalidade do usuário Pedagogo(a) para escolher o cargo disponível dos usuários que solicitaram acesso.

**Pontos importantes:**
- Modal de seleção e confirmação para a escolha do cargo e aprovação do usuário.
- Remoção do fallback que retornava o cargo Professor para qualquer usuário aprovado.

**Problema 1:** Ao selecionar o filtro “Inativos”, nenhum usuário é exibido porque existe uma inconsistência na consulta do backend. Quando um usuário é inativado, seu registro recebe:
```ts
userStatus: "DISABLED"
removed: true
```
Porém, a listagem de usuários aplica sempre a condição:
```ts
removed: false
```
Assim, ao receber `userStatus=DISABLED`, o backend procura registros que sejam simultaneamente inativos e não removidos. Como os usuários inativados estão marcados com `removed: true`, a API está retornando uma lista vazia.

**Problema 2:** Não existe ainda um contrato no backend que habilite a possibilidade de reativar um usuário Inativo.